### PR TITLE
Enable providing custom path for artifact uploading

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -149,7 +149,7 @@ jobs:
       - name: upload artifacts
         if: ${{ inputs.tf_upload_artifacts == 'true' }}
         env:
-          ARTIFACT_PATH: ${{ inputs.working_directory || inputs.tf_upload_artifact_path }}
+          ARTIFACT_PATH: ${{ inputs.tf_upload_artifact_path || inputs.working_directory }}
         uses: actions/upload-artifact@v3.1.2
         with:
           name: tf_artifacts${{ inputs.tf_upload_artifact_name_suffix }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -42,6 +42,9 @@ on:
       tf_upload_artifact_name_suffix:
         default: ''
         type: string
+      tf_upload_artifact_path:
+        default: ''
+        type: string
       tf_sh_version:
         default: '0.2.0'
         type: string
@@ -145,7 +148,9 @@ jobs:
       
       - name: upload artifacts
         if: ${{ inputs.tf_upload_artifacts == 'true' }}
+        env:
+          ARTIFACT_PATH: ${{ inputs.working_directory || inputs.tf_upload_artifact_path }}
         uses: actions/upload-artifact@v3.1.2
         with:
           name: tf_artifacts${{ inputs.tf_upload_artifact_name_suffix }}
-          path: ${{ inputs.working_directory }}
+          path: ${{ env.ARTIFACT_PATH }}


### PR DESCRIPTION
To avoid uploading an artifact of a whole working dir, add a separate input for path that will be used for the artifact uploading