### PR TITLE
Perform the format step before init or validate

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -158,6 +158,11 @@ jobs:
           fi
           chmod +x tf.sh
 
+      # Check terraform specs format
+      - name: terraform fmt
+        working-directory: ${{ inputs.working_directory }}
+        run: terraform fmt --recursive -check=true
+
       # Initialize
       - name: terraform init
         working-directory: ${{ inputs.working_directory }}
@@ -167,11 +172,6 @@ jobs:
       - name: terraform validate
         working-directory: ${{ inputs.working_directory }}
         run: terraform validate -no-color
-
-      # Check terraform specs format
-      - name: terraform fmt
-        working-directory: ${{ inputs.working_directory }}
-        run: terraform fmt --recursive -check=true
 
       # Run terraform plan
       - id: plan


### PR DESCRIPTION
When running a workflow with a badly formatted file, the pipeline can take several seconds to run the init and validate steps of the Github action before failing at the format step.

The format operation is a lot faster than init and validate, so by moving it earlier in the pipeline, the individual contributors receive faster feedback on their work.